### PR TITLE
feat: Platform lock to Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "author": "Giovanni Campagna <gcampagn@cs.stanford.edu>",
   "license": "BSD-3-Clause",
   "gypfile": true,
+  "os": [
+    "linux"
+  ],
   "dependencies": {
     "bindings": "~1.5.0",
     "nan": "^2.13.2"


### PR DESCRIPTION
This is useful because in Electron apps with some bundle configurations, it causes problems with macOS to have this dep